### PR TITLE
Fix erroring openai types schema

### DIFF
--- a/openApiAgent/api.ts
+++ b/openApiAgent/api.ts
@@ -1,29 +1,27 @@
 import { makeApi, Zodios, type ZodiosOptions } from "@zodios/core";
 import { z } from "zod";
 
-const Category = z.object({ id: z.number().int(), name: z.string() }).partial();
-const Tag = z.object({ id: z.number().int(), name: z.string() }).partial();
+const Category = z.object({ id: z.number().int(), name: z.string() });
+const Tag = z.object({ id: z.number().int(), name: z.string() });
 const Pet = z.object({
-  id: z.number().int().optional(),
+  id: z.number().int(),
   name: z.string(),
-  category: Category.optional(),
+  category: Category,
   photoUrls: z.array(z.string()),
-  tags: z.array(Tag).optional(),
-  status: z.enum(["available", "pending", "sold"]).optional(),
+  tags: z.array(Tag),
+  status: z.enum(["available", "pending", "sold"]),
 });
 const ApiResponse = z
-  .object({ code: z.number().int(), type: z.string(), message: z.string() })
-  .partial();
+  .object({ code: z.number().int(), type: z.string(), message: z.string() });
 const Order = z
   .object({
     id: z.number().int(),
     petId: z.number().int(),
     quantity: z.number().int(),
-    shipDate: z.string().datetime({ offset: true }),
+    shipDate: z.string(),
     status: z.enum(["placed", "approved", "delivered"]),
     complete: z.boolean(),
-  })
-  .partial();
+  });
 const User = z
   .object({
     id: z.number().int(),
@@ -34,8 +32,7 @@ const User = z
     password: z.string(),
     phone: z.string(),
     userStatus: z.number().int(),
-  })
-  .partial();
+  });
 
 export const schemas = {
   Category,
@@ -187,30 +184,30 @@ const endpoints = makeApi([
       },
     ],
   },
-  {
-    method: "post",
-    path: "/pet/:petId/uploadImage",
-    alias: "uploadFile",
-    requestFormat: "binary",
-    parameters: [
-      {
-        name: "body",
-        type: "Body",
-        schema: z.instanceof(File),
-      },
-      {
-        name: "petId",
-        type: "Path",
-        schema: z.number().int(),
-      },
-      {
-        name: "additionalMetadata",
-        type: "Query",
-        schema: z.string().optional(),
-      },
-    ],
-    response: ApiResponse,
-  },
+  // {
+  //   method: "post",
+  //   path: "/pet/:petId/uploadImage",
+  //   alias: "uploadFile",
+  //   requestFormat: "binary",
+  //   parameters: [
+  //     {
+  //       name: "body",
+  //       type: "Body",
+  //       schema: z.instanceof(File),
+  //     },
+  //     {
+  //       name: "petId",
+  //       type: "Path",
+  //       schema: z.number().int(),
+  //     },
+  //     {
+  //       name: "additionalMetadata",
+  //       type: "Query",
+  //       schema: z.string().optional(),
+  //     },
+  //   ],
+  //   response: ApiResponse,
+  // },
   {
     method: "get",
     path: "/pet/findByStatus",


### PR DESCRIPTION
Fixes https://github.com/UpstreetAI/upstreet-core/issues/707

I mostly had to get rid of the `.partial()` and `.optional()` on the shared schemas. Apparently openai's library (`import { zodResponseFormat } from 'openai/helpers/zod'`) does not support optional schemas at all; they recommend using union with null instead: https://platform.openai.com/docs/guides/structured-outputs#all-fields-must-be-required

I also had to remove some incompatible schemas, such as a Date, and one that included `z.instanceof(File)`. Neither of these are compatible with OpenAI or their lib.